### PR TITLE
docs(env): clarify API URL examples for iOS and Android emulators

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
-EXPO_PUBLIC_API_URL="http://localhost:3000"
+EXPO_PUBLIC_API_URL="http://localhost:3000" # iOS simulator localhost
+# EXPO_PUBLIC_API_URL="http://10.0.2.2:3000" # Android emulator localhost
 
 EXPO_PUBLIC_GOOGLE_OAUTH_WEB_CLIENT_ID=""
 EXPO_PUBLIC_GOOGLE_OAUTH_IOS_CLIENT_ID=""


### PR DESCRIPTION
Added comments to EXPO_PUBLIC_API_URL in .env.example to specify usage for iOS simulator and Android emulator, improving developer clarity.