### PR TITLE
feat(splash-screen): prevent auto-hide while fetching resources

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "expo-linking": "^8.0.8",
     "expo-router": "^6.0.13",
     "expo-secure-store": "^15.0.7",
+    "expo-splash-screen": "~31.0.10",
     "expo-status-bar": "~3.0.8",
     "expo-system-ui": "^6.0.8",
     "lucide-react-native": "^0.514.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,6 +92,9 @@ importers:
       expo-secure-store:
         specifier: ^15.0.7
         version: 15.0.7(expo@54.0.20)
+      expo-splash-screen:
+        specifier: ~31.0.10
+        version: 31.0.10(expo@54.0.20)
       expo-status-bar:
         specifier: ~3.0.8
         version: 3.0.8(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
@@ -3456,6 +3459,11 @@ packages:
   expo-server@1.0.2:
     resolution: {integrity: sha512-QlQLjFuwgCiBc+Qq0IyBBHiZK1RS0NJSsKVB5iECMJrR04q7PhkaF7dON0fhvo00COy4fT9rJ5brrJDpFro/gA==}
     engines: {node: '>=20.16.0'}
+
+  expo-splash-screen@31.0.10:
+    resolution: {integrity: sha512-i6g9IK798mae4yvflstQ1HkgahIJ6exzTCTw4vEdxV0J2SwiW3Tj+CwRjf0te7Zsb+7dDQhBTmGZwdv00VER2A==}
+    peerDependencies:
+      expo: '*'
 
   expo-status-bar@3.0.8:
     resolution: {integrity: sha512-L248XKPhum7tvREoS1VfE0H6dPCaGtoUWzRsUv7hGKdiB4cus33Rc0sxkWkoQ77wE8stlnUlL5lvmT0oqZ3ZBw==}
@@ -10662,6 +10670,13 @@ snapshots:
       expo: 54.0.20(@babel/core@7.28.5)(@expo/metro-runtime@6.1.2)(expo-router@6.0.13)(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
 
   expo-server@1.0.2: {}
+
+  expo-splash-screen@31.0.10(expo@54.0.20):
+    dependencies:
+      '@expo/prebuild-config': 54.0.6(expo@54.0.20)
+      expo: 54.0.20(@babel/core@7.28.5)(@expo/metro-runtime@6.1.2)(expo-router@6.0.13)(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+    transitivePeerDependencies:
+      - supports-color
 
   expo-status-bar@3.0.8(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:

--- a/src/features/splash-screen-controller/index.tsx
+++ b/src/features/splash-screen-controller/index.tsx
@@ -1,4 +1,4 @@
-import { SplashScreen } from "expo-router";
+import * as SplashScreen from "expo-splash-screen";
 import { useSessionStore } from "../../hooks/use-session-store";
 
 // Keep the splash screen visible while we fetch resources


### PR DESCRIPTION
Added SplashScreen.preventAutoHideAsync to keep the splash screen visible during resource fetching, ensuring users do not see incomplete UI while loading.